### PR TITLE
Upgrading Dropwizard from 1.2.0 to 1.2.8 for dependencies security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This project is available on Maven Central. To add it to your project simply add
     <dependency>
       <groupId>com.engagetech.dropwizard.modules</groupId>
       <artifactId>dropwizard-elasticsearch</artifactId>
-      <version>1.2.0-2-ES6.0.1</version>
+      <version>1.2.8-ES6.0.1</version>
     </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.engagetech.dropwizard.modules</groupId>
     <artifactId>dropwizard-elasticsearch</artifactId>
-    <version>1.2.8-ES6.0.1-4</version>
+    <version>1.2.8-ES6.0.1</version>
     <packaging>jar</packaging>
 
     <name>Dropwizard Elasticsearch Bundle</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.engagetech.dropwizard.modules</groupId>
     <artifactId>dropwizard-elasticsearch</artifactId>
-    <version>1.2.0-2-ES6.0.1-4</version>
+    <version>1.2.8-ES6.0.1-4</version>
     <packaging>jar</packaging>
 
     <name>Dropwizard Elasticsearch Bundle</name>
@@ -70,7 +70,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <log4j.version>2.8.1</log4j.version>
-        <dropwizard.version>1.2.0</dropwizard.version>
+        <dropwizard.version>1.2.8</dropwizard.version>
         <elasticsearch.version>6.0.1</elasticsearch.version>
     </properties>
 


### PR DESCRIPTION
For list of fixes check https://github.com/dropwizard/dropwizard/blob/master/docs/source/about/release-notes.rst

Notable: Upgrade to Jetty 9.4.11.v20180605